### PR TITLE
numbering.xml的Relationship应添加到documentRelationships中

### DIFF
--- a/pkg/document/numbering.go
+++ b/pkg/document/numbering.go
@@ -405,7 +405,7 @@ func (d *Document) updateNumberingFile() {
 // addNumberingRelationship 添加编号关系
 func (d *Document) addNumberingRelationship() {
 	// 生成关系ID
-	relationshipID := fmt.Sprintf("rId%d", len(d.relationships.Relationships)+1)
+	relationshipID := fmt.Sprintf("rId%d", len(d.documentRelationships.Relationships)+2) // +2 因为已有样式styles.xml定义
 
 	// 添加关系
 	relationship := Relationship{
@@ -413,7 +413,7 @@ func (d *Document) addNumberingRelationship() {
 		Type:   "http://schemas.openxmlformats.org/officeDocument/2006/relationships/numbering",
 		Target: "numbering.xml",
 	}
-	d.relationships.Relationships = append(d.relationships.Relationships, relationship)
+	d.documentRelationships.Relationships = append(d.documentRelationships.Relationships, relationship)
 }
 
 // RestartNumbering 重新开始编号


### PR DESCRIPTION
numbering.xml应该添加到documentRelationships里，在```word/_ref/document.xml.rels```中：
```
<?xml version="1.0" encoding="UTF-8"?>
<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles" Target="styles.xml"></Relationship>
  <Relationship Id="rId2" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/numbering" Target="numbering.xml"></Relationship>
</Relationships>
```
