### PR TITLE
✨ feat: 混合格式段落字体下划线和删除线

### DIFF
--- a/examples/formatting/formatted_text_demo.go
+++ b/examples/formatting/formatted_text_demo.go
@@ -15,6 +15,8 @@ func main() {
 		{FontFamily: "Times New Roman", FontSize: 14, Italic: true},
 		{FontFamily: "Courier New", FontSize: 10, FontColor: "FF0000"},
 		{FontFamily: "Calibri", FontSize: 16, Bold: true, Italic: true},
+		{FontFamily: "Calibri", FontSize: 16, Underline: true},
+		{FontFamily: "Calibri", FontSize: 16, Strike: true},
 	}
 
 	texts := []string{
@@ -22,6 +24,8 @@ func main() {
 		"这是斜体文本",
 		"这是红色文本",
 		"这是粗体斜体文本",
+		"这是下划线文本",
+		"这是删除线文本",
 	}
 
 	for i, text := range texts {

--- a/examples/formatting/formatted_text_demo.go
+++ b/examples/formatting/formatted_text_demo.go
@@ -17,6 +17,7 @@ func main() {
 		{FontFamily: "Calibri", FontSize: 16, Bold: true, Italic: true},
 		{FontFamily: "Calibri", FontSize: 16, Underline: true},
 		{FontFamily: "Calibri", FontSize: 16, Strike: true},
+		{FontFamily: "微软雅黑", FontSize: 18, Highlight: "yellow"},
 	}
 
 	texts := []string{
@@ -26,6 +27,7 @@ func main() {
 		"这是粗体斜体文本",
 		"这是下划线文本",
 		"这是删除线文本",
+		"这是高亮文本",
 	}
 
 	for i, text := range texts {

--- a/pkg/document/document.go
+++ b/pkg/document/document.go
@@ -282,6 +282,8 @@ type TextFormat struct {
 	FontSize   int    // 字体大小（磅）
 	FontColor  string // 字体颜色（十六进制，如 "FF0000" 表示红色）
 	FontFamily string // 字体名称
+	Underline  bool   // 是否下划线
+	Strike     bool   // 删除线
 }
 
 // AlignmentType 对齐类型
@@ -628,6 +630,13 @@ func (d *Document) AddFormattedParagraph(text string, format *TextFormat) *Parag
 		if format.FontSize > 0 {
 			// Word中字体大小是半磅为单位，所以需要乘以2
 			runProps.FontSize = &FontSize{Val: strconv.Itoa(format.FontSize * 2)}
+		}
+		if format.Underline {
+			runProps.Underline = &Underline{Val: "single"} // 默认单线下划线
+		}
+
+		if format.Strike {
+			runProps.Strike = &Strike{} // 添加删除线
 		}
 	}
 

--- a/pkg/document/document.go
+++ b/pkg/document/document.go
@@ -798,6 +798,13 @@ func (p *Paragraph) AddFormattedText(text string, format *TextFormat) {
 		if format.FontSize > 0 {
 			runProps.FontSize = &FontSize{Val: strconv.Itoa(format.FontSize * 2)}
 		}
+		if format.Underline {
+			runProps.Underline = &Underline{Val: "single"} // 默认单线下划线
+		}
+
+		if format.Strike {
+			runProps.Strike = &Strike{} // 添加删除线
+		}
 	}
 
 	run := Run{

--- a/pkg/document/document.go
+++ b/pkg/document/document.go
@@ -284,6 +284,7 @@ type TextFormat struct {
 	FontFamily string // 字体名称
 	Underline  bool   // 是否下划线
 	Strike     bool   // 删除线
+	Highlight  string //高亮颜色
 }
 
 // AlignmentType 对齐类型
@@ -610,7 +611,7 @@ func (d *Document) AddFormattedParagraph(text string, format *TextFormat) *Parag
 
 	if format != nil {
 		if format.FontFamily != "" {
-			runProps.FontFamily = &FontFamily{ASCII: format.FontFamily}
+			runProps.FontFamily = &FontFamily{EastAsia: format.FontFamily}
 		}
 
 		if format.Bold {
@@ -637,6 +638,10 @@ func (d *Document) AddFormattedParagraph(text string, format *TextFormat) *Parag
 
 		if format.Strike {
 			runProps.Strike = &Strike{} // 添加删除线
+		}
+
+		if format.Highlight != "" {
+			runProps.Highlight = &Highlight{Val: format.Highlight}
 		}
 	}
 
@@ -779,7 +784,7 @@ func (p *Paragraph) AddFormattedText(text string, format *TextFormat) {
 
 	if format != nil {
 		if format.FontFamily != "" {
-			runProps.FontFamily = &FontFamily{ASCII: format.FontFamily}
+			runProps.FontFamily = &FontFamily{EastAsia: format.FontFamily}
 		}
 
 		if format.Bold {
@@ -804,6 +809,10 @@ func (p *Paragraph) AddFormattedText(text string, format *TextFormat) {
 
 		if format.Strike {
 			runProps.Strike = &Strike{} // 添加删除线
+		}
+
+		if format.Highlight != "" {
+			runProps.Highlight = &Highlight{Val: format.Highlight}
 		}
 	}
 


### PR DESCRIPTION
感谢大佬开源这么好用的库

这里文档好像对不上，我自己使用需要用到下划线和空格做占位符，所以改了一下
https://github.com/ZeroHawkeye/wordZero/wiki/04-%E6%96%87%E6%9C%AC%E6%A0%BC%E5%BC%8F%E5%8C%96

我看到源码中是
<img width="735" height="244" alt="image" src="https://github.com/user-attachments/assets/c5ec6e35-709b-4163-8fb0-c066dd7f13a5" />
但是文档中是
<img width="484" height="275" alt="image" src="https://github.com/user-attachments/assets/c0931955-2385-46bc-af29-f569b3d9f209" />
缺少字段并且`字体名`这个字段也对不上，还麻烦大佬有空瞅瞅