### PR TITLE
Fix: 修复通过Open打开的文档在Save后无法正常打开的问题

### DIFF
--- a/test/document_test.go
+++ b/test/document_test.go
@@ -64,3 +64,56 @@ func TestOpenDocument(t *testing.T) {
 
 	t.Log("Document opened successfully")
 }
+
+func TestOpenModifySaveReopen(t *testing.T) {
+	// 首先创建一个文档
+	doc := document.New()
+	doc.AddParagraph("Original paragraph")
+
+	testFile := "test_output/test_modify.docx"
+	err := doc.Save(testFile)
+	if err != nil {
+		t.Fatalf("Failed to save document: %v", err)
+	}
+
+	// 打开文档
+	openedDoc, err := document.Open(testFile)
+	if err != nil {
+		t.Fatalf("Failed to open document: %v", err)
+	}
+
+	// 修改文档
+	openedDoc.AddParagraph("Added paragraph")
+
+	// 保存修改后的文档
+	modifiedFile := "test_output/test_modify_saved.docx"
+	err = openedDoc.Save(modifiedFile)
+	if err != nil {
+		t.Fatalf("Failed to save modified document: %v", err)
+	}
+
+	// 再次打开修改后的文档
+	reopenedDoc, err := document.Open(modifiedFile)
+	if err != nil {
+		t.Fatalf("Failed to reopen modified document: %v", err)
+	}
+
+	// 验证内容
+	paragraphs := reopenedDoc.Body.GetParagraphs()
+	if len(paragraphs) != 2 {
+		t.Fatalf("Expected 2 paragraphs, got %d", len(paragraphs))
+	}
+
+	if paragraphs[0].Runs[0].Text.Content != "Original paragraph" {
+		t.Fatalf("First paragraph content mismatch")
+	}
+
+	if paragraphs[1].Runs[0].Text.Content != "Added paragraph" {
+		t.Fatalf("Second paragraph content mismatch")
+	}
+
+	// 清理测试文件
+	defer os.RemoveAll("test_output")
+
+	t.Log("Document open-modify-save-reopen test passed")
+}


### PR DESCRIPTION
## 问题描述
修复 Issue #14 ：通过 `Open()` 方法打开的文档在 `Save()` 后无法再次打开。

## 修改内容
1. **在 `Open()` 函数中添加解析逻辑**
   - 调用新增的 `parseContentTypes()` 方法解析 `[Content_Types].xml`
   - 调用新增的 `parseRelationships()` 方法解析 `_rels/.rels`
   - 如果解析失败，使用默认值

2. **添加两个新的解析方法**
   - `parseContentTypes()`: 从 `parts` 中读取并解析 `[Content_Types].xml`
   - `parseRelationships()`: 从 `parts` 中读取并解析 `_rels/.rels`


## 测试验证
所有相关测试都通过：
```
✅ TestCreateDocument - 创建新文档并保存
✅ TestOpenDocument - 打开文档
✅ TestOpenModifySaveReopen - 打开-修改-保存-再次打开（新增测试）
```

## 文件内容验证
修复前：`test_open_modified.docx` 中的 `_rels/.rels` 和 `[Content_Types].xml` 为空
修复后：这些文件包含正确的 XML 内容

## 相关链接
- Issue #14 
