### PR TITLE
Preserve template header/footer references during DOCX rendering (#76)

### DIFF
--- a/pkg/document/page.go
+++ b/pkg/document/page.go
@@ -345,6 +345,27 @@ func (d *Document) getSectionProperties() *SectionProperties {
 	return sectPr
 }
 
+// setSectionProperties 替换或设置节属性
+func (d *Document) setSectionProperties(sectPr *SectionProperties) {
+	if sectPr == nil {
+		return
+	}
+
+	if d.Body == nil {
+		d.Body = &Body{Elements: []interface{}{sectPr}}
+		return
+	}
+
+	for i, element := range d.Body.Elements {
+		if _, ok := element.(*SectionProperties); ok {
+			d.Body.Elements[i] = sectPr
+			return
+		}
+	}
+
+	d.Body.Elements = append(d.Body.Elements, sectPr)
+}
+
 // ElementType 返回节属性元素类型
 func (s *SectionProperties) ElementType() string {
 	return "sectionProperties"


### PR DESCRIPTION
  * Initial plan

  * Parse `<w:sectPr>` blocks even when Word nests them inside paragraph properties and use a new `setSectionProperties` helper so cloned templates keep the
  original section metadata (including header/footer references)

  * Preserve each section’s `xmlns:r` attribute and `r:id` header/footer relationships when reading DOCX files to prevent headers from being dropped during
  serialization

  * Add a regression test that rewrites a DOCX to place section properties inside a paragraph and confirms header/footer variables are still replaced