### PR TITLE
fix: 修改模板引擎循环处理嵌套结构体时替换占位符时机

### DIFF
--- a/pkg/document/sdt.go
+++ b/pkg/document/sdt.go
@@ -190,38 +190,11 @@ func (sdt *SDT) AddTOCEntry(text string, level int, pageNum int, entryID string)
 		Runs: []Run{},
 	}
 
-	// 创建内嵌的SDT用于占位符文本
-	placeholderSDT := &SDT{
-		Properties: &SDTProperties{
-			RunPr: &RunProperties{
-				FontFamily: &FontFamily{ASCII: "Calibri"},
-				FontSize:   &FontSize{Val: "22"},
-			},
-			ID: &SDTID{Val: entryID},
-			Placeholder: &SDTPlaceholder{
-				DocPart: &DocPart{Val: generatePlaceholderGUID(level)},
-			},
-			Color: &SDTColor{Val: "509DF3"},
-		},
-		EndPr: &SDTEndPr{
-			RunPr: &RunProperties{
-				FontFamily: &FontFamily{ASCII: "Calibri"},
-				FontSize:   &FontSize{Val: "22"},
-			},
-		},
-		Content: &SDTContent{
-			Elements: []interface{}{
-				Run{
-					Text: Text{Content: text},
-				},
-			},
-		},
+	// 创建标题文本、制表符和页码的Run
+	textRun := Run{
+		Text: Text{Content: text},
 	}
 
-	// 将占位符SDT添加到段落中
-	sdt.Content.Elements = append(sdt.Content.Elements, placeholderSDT)
-
-	// 创建包含制表符和页码的文本Run
 	tabRun := Run{
 		Text: Text{Content: "\t"},
 	}
@@ -230,24 +203,10 @@ func (sdt *SDT) AddTOCEntry(text string, level int, pageNum int, entryID string)
 		Text: Text{Content: fmt.Sprintf("%d", pageNum)},
 	}
 
-	entryPara.Runs = append(entryPara.Runs, tabRun, pageRun)
+	entryPara.Runs = append(entryPara.Runs, textRun, tabRun, pageRun)
 
 	// 添加段落到SDT内容中
 	sdt.Content.Elements = append(sdt.Content.Elements, entryPara)
-}
-
-// generatePlaceholderGUID 生成占位符GUID
-func generatePlaceholderGUID(level int) string {
-	guids := map[int]string{
-		1: "{b5fdec38-8301-4b26-9716-d8b31c00c718}",
-		2: "{a500490c-aaae-4252-8340-aa59729b9870}",
-		3: "{d7310822-77d9-4e43-95e1-4649f1e215b3}",
-	}
-
-	if guid, exists := guids[level]; exists {
-		return guid
-	}
-	return "{b5fdec38-8301-4b26-9716-d8b31c00c718}" // 默认使用1级
 }
 
 // FinalizeTOCSDT 完成目录SDT构建

--- a/pkg/document/template.go
+++ b/pkg/document/template.go
@@ -556,12 +556,6 @@ func (te *TemplateEngine) renderLoopsNested(content string, lists map[string][]i
 	// 渲染循环
 	if listData, exists := lists[listVar]; exists {
 		for i, item := range listData {
-			// 创建循环上下文变量
-			loopContent := strings.ReplaceAll(blockContent, "{{this}}", te.interfaceToString(item))
-			loopContent = strings.ReplaceAll(loopContent, "{{@index}}", strconv.Itoa(i))
-			loopContent = strings.ReplaceAll(loopContent, "{{@first}}", strconv.FormatBool(i == 0))
-			loopContent = strings.ReplaceAll(loopContent, "{{@last}}", strconv.FormatBool(i == len(listData)-1))
-
 			// 如果item是map，处理属性访问
 			if itemMap, ok := item.(map[string]interface{}); ok {
 				// 首先处理嵌套的循环（在替换变量之前）
@@ -576,7 +570,7 @@ func (te *TemplateEngine) renderLoopsNested(content string, lists map[string][]i
 
 				// 如果有嵌套列表，递归处理嵌套循环
 				if len(nestedLists) > 0 {
-					loopContent = te.renderLoopsNested(loopContent, nestedLists, depth+1)
+					blockContent = te.renderLoopsNested(blockContent, nestedLists, depth+1)
 				}
 
 				// 然后替换普通变量
@@ -584,15 +578,19 @@ func (te *TemplateEngine) renderLoopsNested(content string, lists map[string][]i
 					placeholder := fmt.Sprintf("{{%s}}", key)
 					// 只替换非列表类型的值
 					if _, isList := value.([]interface{}); !isList {
-						loopContent = strings.ReplaceAll(loopContent, placeholder, te.interfaceToString(value))
+						blockContent = strings.ReplaceAll(blockContent, placeholder, te.interfaceToString(value))
 					}
 				}
 
 				// 处理循环内部的条件语句
-				loopContent = te.renderLoopConditionals(loopContent, itemMap)
+				blockContent = te.renderLoopConditionals(blockContent, itemMap)
 			}
 
-			result.WriteString(loopContent)
+			blockContent = strings.ReplaceAll(blockContent, "{{this}}", te.interfaceToString(item))
+			blockContent = strings.ReplaceAll(blockContent, "{{@index}}", strconv.Itoa(i))
+			blockContent = strings.ReplaceAll(blockContent, "{{@first}}", strconv.FormatBool(i == 0))
+			blockContent = strings.ReplaceAll(blockContent, "{{@last}}", strconv.FormatBool(i == len(listData)-1))
+			result.WriteString(blockContent)
 		}
 	}
 


### PR DESCRIPTION
## 问题
模板引擎在循环语句中渲染嵌套结构体时, 变量替换时机不正确, 嵌套的数据会被覆盖导致渲染失败
以https://github.com/zerx-lab/wordZero/wiki/12-%E6%A8%A1%E6%9D%BF%E5%8A%9F%E8%83%BD#3-%E4%BC%9A%E8%AE%AE%E8%AE%B0%E5%BD%95%E6%A8%A1%E6%9D%BF
为例,  agendaItems中嵌套discussionPoints, 执行代码后生成的word如下:
<img width="714" height="504" alt="image" src="https://github.com/user-attachments/assets/4facf569-191f-4eb3-84ea-004443e4a350" />

## 修复方式
修改渲染时机, 如果检测到有map结构, 先处理map,最后再替换.

## 测试
修改后可以正常处理嵌套结构体。
<img width="940" height="663" alt="image" src="https://github.com/user-attachments/assets/a73af2ff-7e4c-4b6f-af9f-241e15c1d16d" />

